### PR TITLE
Unified usage of <- vs =

### DIFF
--- a/Yeast_cell_growth.ipynb
+++ b/Yeast_cell_growth.ipynb
@@ -161,10 +161,10 @@
     }
    ],
    "source": [
-    "threshImg = thresh(img, w=20, h=20, offset=0.05)\n",
+    "threshImg <- thresh(img, w=20, h=20, offset=0.05)\n",
     "threshImg <- medianFilter(threshImg, 3)\n",
-    "threshImg = fillHull(threshImg)\n",
-    "threshImg = bwlabel(threshImg)\n",
+    "threshImg <- fillHull(threshImg)\n",
+    "threshImg <- bwlabel(threshImg)\n",
     "EBImage::display(colorLabels(threshImg))"
    ]
   },
@@ -221,10 +221,10 @@
     "  pixels <- getPixelValues(image, 1, t, 2)\n",
     "  ebi <- EBImage::Image(data = pixels, colormode = 'Grayscale')\n",
     "  img <- normalize(ebi)\n",
-    "  threshImg = thresh(img, w=20, h=20, offset=0.05)\n",
+    "  threshImg <- thresh(img, w=20, h=20, offset=0.05)\n",
     "  threshImg <- medianFilter(threshImg, 3)\n",
-    "  threshImg = fillHull(threshImg)\n",
-    "  threshImg = bwlabel(threshImg)\n",
+    "  threshImg <- fillHull(threshImg)\n",
+    "  threshImg <- bwlabel(threshImg)\n",
     "  count <- range(threshImg)\n",
     "  as.integer(count[2])\n",
     "}"


### PR DESCRIPTION
If I could add another small change, this PR would unify the usage of `<-` and `=`. Don't know how this inconsistency slipped in. Both work, but looks a bit strange.